### PR TITLE
Switch to Rust edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "co2-fe2o3"
 version = "0.1.0"
+edition = "2018"
 authors = ["Clemens Lang <neverpanic@gmail.com>"]
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
-extern crate serde;
+
 #[macro_use]
 extern crate serde_derive;
-extern crate toml;
+use toml;
 
 mod sensor;
 mod sink;
 
-use sensor::Sensor;
-use sink::SinkConfig;
+use crate::sensor::Sensor;
+use crate::sink::SinkConfig;
 
 use std::env;
 use std::error;

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -1,7 +1,7 @@
-extern crate hidapi;
-extern crate rand;
-extern crate crypto;
-extern crate chrono;
+use hidapi;
+use rand;
+use crypto;
+
 
 use self::crypto::digest::Digest;
 use self::crypto::sha2::Sha256;

--- a/src/sink/influx.rs
+++ b/src/sink/influx.rs
@@ -1,6 +1,6 @@
-extern crate chrono;
-extern crate influx_db_client;
-extern crate native_tls;
+use chrono;
+use influx_db_client;
+use native_tls;
 
 use self::chrono::{Utc, Duration};
 use self::influx_db_client::{Client, Point, Points, Value, Precision, TLSOption};

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -1,4 +1,4 @@
-extern crate chrono;
+use chrono;
 
 pub mod influx;
 pub mod print;
@@ -18,7 +18,7 @@ pub enum SinkConfig {
 }
 
 pub trait Sink {
-    fn add_measurement(&mut self, &Measurement);
+    fn add_measurement(&mut self, _: &Measurement);
     fn submit(&mut self);
 }
 
@@ -30,7 +30,7 @@ pub enum Value {
 }
 
 impl fmt::Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Value::String(val) => write!(f, "{}", val),
             Value::Integer(val) => write!(f, "{}", val),
@@ -80,7 +80,7 @@ impl Measurement {
 }
 
 impl fmt::Display for Measurement {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} ",

--- a/src/sink/print.rs
+++ b/src/sink/print.rs
@@ -1,4 +1,4 @@
-extern crate chrono;
+
 
 use super::Sink;
 


### PR DESCRIPTION
Switch the edition and apply all fixes and idiom migrations.