### PR TITLE
Fix unused borrow warning

### DIFF
--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -42,7 +42,7 @@ impl Sensor {
 
         // Send key to device
         let mut buf: [u8; 9] = [0; 9];
-        &buf[1..9].clone_from_slice(&key[..]);
+        buf[1..9].clone_from_slice(&key[..]);
         if device.send_feature_report(&buf).is_err() {
             return None;
         }


### PR DESCRIPTION
The borrow here isn't necessary, as rustc will automatically borrow
`buf[1..9]` as the `self` parameter for `clone_from_slice`, and it
wouldn't be sufficient if it were necessary, since `clone_from_slice`
takes `&mut self`.